### PR TITLE
fix: constrain date field width in quest creation form

### DIFF
--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -284,12 +284,14 @@ export function PlanDetail() {
             </div>
           ) : (
             <div className="w-full space-y-4">
-              <Input
-                label="Start Date"
-                type="date"
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
-              />
+              <div className="max-w-xs">
+                <Input
+                  label="Start Date"
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                />
+              </div>
               <Button
                 variant="primary"
                 className="w-full"


### PR DESCRIPTION
## Summary
- Fixed the START DATE input field that was extending full-width and looking disproportionate
- Wrapped the date input in a `max-w-xs` container to constrain width to 320px
- Makes the form layout more balanced and visually appropriate for date content

## Changes
- Modified `src/pages/PlanDetail.tsx` to wrap the date Input component in a `max-w-xs` div

## Screenshots
Before: Date field extended full-width
After: Date field constrained to appropriate width for date format

## Closes
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)